### PR TITLE
Added support for access-listing on the port level

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Enter cookie-toss. This package allows you to store all user data on a central (
 
 cookie-toss provides both code for the iframe hosted on the hub domain, as well as the data getters and setters for the satellite domains.
 
-The minimum setup just involves deploying the iframe code with a list of white-listed satellite domains to your hub domain, and using the `get` and `set` functions in apps on the satellite domains.
+The minimum setup just involves deploying the iframe code with a list of access-listed satellite domains to your hub domain, and using the `get` and `set` functions in apps on the satellite domains.
 
 <div style="margin: 5px 10px; border: solid 1px #000fbe24; background: #0366d60f; padding: 10px;">
   <b>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cookie-toss",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "description": "A package that makes sharing local data across domains a thing of ease.",
   "main": "lib/index.js",
   "types": "lib/index.d.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cookie-toss",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "A package that makes sharing local data across domains a thing of ease.",
   "main": "lib/index.js",
   "types": "lib/index.d.js",

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -53,9 +53,22 @@ export interface IframeRoutes {
 export type IframeListener = (specs: IframeListenerSpecs) => Promise<void>;
 
 /**
+ * A package of data to ID accepted hosts:
+ */
+export type HostSpecs = {
+    hostname: string;
+    port: string;
+}
+
+/**
  * An array of domains where satellite sites reside:
  */
 export type DependentDomains = string[]
+
+/**
+ * An array of domain specs where satellite sites reside:
+ */
+export type DependentDomainSpecs = HostSpecs[]
 
 /**
  * The object the configures a single data endpoint within the iframe:

--- a/src/common/urlUtils.ts
+++ b/src/common/urlUtils.ts
@@ -1,6 +1,14 @@
 import UrlParser from 'url-parse';
+import { HostSpecs } from './types';
 
-export const getHostname = (origin: string): string => (new UrlParser(origin)).hostname;
+export const getHostnameAndPort = (origin: string): HostSpecs => {
+    // If an origin was entered without protocol, prepend with one to allow for parsing
+    if (!/^http/.test(origin)) {
+        origin = `http://${origin}`
+    }
+    const { hostname, port } = new UrlParser(origin);
+    return { hostname, port }
+}
 
 export const getDomainAndPath = (origin: string): string => {
     const urlParts = new UrlParser(origin)

--- a/src/iframe/index.ts
+++ b/src/iframe/index.ts
@@ -16,7 +16,7 @@ export const createIframe = ({
     const dependentDomainSpecs: DependentDomainSpecs = [origin, ...dependentDomains].map(domain => getHostnameAndPort(domain))
 
     // Create the listener, which picks up requests, filters
-    // out non-accesslisted domains, and receives data based on
+    // out non-access-listed domains, and receives data based on
     // the dataKey of the response:
     setIframeListener({ routes, dependentDomainSpecs });
 }

--- a/src/iframe/index.ts
+++ b/src/iframe/index.ts
@@ -1,7 +1,7 @@
 import { setIframeListener } from './iframeListener';
 import { createIframeRoutes } from './createIframeRoutes';
-import { IframeConfig } from '../common/types';
-import { getHostname } from '../common/urlUtils';
+import { IframeConfig, DependentDomainSpecs } from '../common/types';
+import { getHostnameAndPort } from '../common/urlUtils';
 
 export const createIframe = ({
     dependentDomains,
@@ -11,11 +11,12 @@ export const createIframe = ({
     // Create routes for default and custom data getters.
     const routes = createIframeRoutes(dataConfigs)
 
-    // Add the local domain to the whitelisted domains by default:
-    dependentDomains.push(getHostname(origin))
+    // Extract hostname and port from each dependent, for use in future matching.
+    // Add the local domain to the access-listed domains by default.
+    const dependentDomainSpecs: DependentDomainSpecs = [origin, ...dependentDomains].map(domain => getHostnameAndPort(domain))
 
     // Create the listener, which picks up requests, filters
-    // out non-whitelisted domains, and receives data based on
+    // out non-accesslisted domains, and receives data based on
     // the dataKey of the response:
-    setIframeListener(routes, dependentDomains);
+    setIframeListener({ routes, dependentDomainSpecs });
 }


### PR DESCRIPTION
This PR allows an address with a port to be added to the dependent access list.  In this case, when the requester does not have a matching port, the request will be denied.